### PR TITLE
Filtering is now way faster.

### DIFF
--- a/src/slang/ui/components/blueprint-select.ts
+++ b/src/slang/ui/components/blueprint-select.ts
@@ -174,7 +174,7 @@ export class BlueprintSelectComponent extends CellComponent {
 	}
 
 	private getBlueprints(): BlueprintModel[] {
-		return this.blueprints.filter(this.isFilterExprIncluded, this)
+		return this.blueprints.filter(this.isFilterExprIncluded, this);
 	}
 
 	private placeGhostRect({}: XY, blueprint?: BlueprintModel): BlackBoxShape {


### PR DESCRIPTION
We just initialize the list once and sort it right away by name and later on we just filter the list.
This avoids having to rebuild the list on each keydown and makes selection snappier and responsive.
It also avoids the magic number `60` and make less assumptions about what the use might expect.

**Highlights:**
- faster rendering on keyboard events
- simpler logic