### PR TITLE
Include the reference in the port info

### DIFF
--- a/src/slang/ui/components/whitebox.ts
+++ b/src/slang/ui/components/whitebox.ts
@@ -578,7 +578,7 @@ class PortInfo implements ClassComponent<Attrs> {
 					class: tid2css(tid),
 				},
 				TypeIdentifier[tid]),
-			m(".sl-port-name", port.getName()),
+			m(".sl-port-name", port.getPortReference()),
 		);
 	}
 }


### PR DESCRIPTION
This PR introduces the Portreference string in the PortInfo which makes it easier to read the nested map parameter names that are the same. See Image
##### From Map
![Screenshot 2019-11-01 at 17 16 41](https://user-images.githubusercontent.com/35398/68038991-7865aa00-fccb-11e9-81ac-fdd14c624c53.png)
##### To Map
![Screenshot 2019-11-01 at 17 17 41](https://user-images.githubusercontent.com/35398/68039029-8adfe380-fccb-11e9-8395-26eb4ad17b5b.png)



-- closes #126 